### PR TITLE
Add modified build instructions for Mac local build.

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -44,6 +44,8 @@ $ brew update && brew install automake libtool llvm cmake ninja doxygen git
 ## Building the Library
 Run the following commands to pull and build the ML-IO C++ library.
 
+### Linux build commands
+
 ```bash
 $ git clone https://github.com/awslabs/ml-io.git mlio
 $ cd mlio
@@ -53,6 +55,18 @@ $ cd build/release
 $ cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH="$(pwd)/../third-party" ../..
 $ cmake --build . -- -j $(nproc)
 ```
+
+### Mac build commands
+Mac environments default to a proprietary version of LLVM and Clang which do not work with ML-IO build. It is recommended to use the LLVM that is installed via Homebrew; this version is usually found in ```/usr/local/opt/llvm/bin/clang``` after installation.
+
+```bash
+$ git clone https://github.com/awslabs/ml-io.git mlio
+$ cd mlio
+$ build-tools/build-dependency build/third-party all
+$ mkdir build/release
+$ cd build/release
+$ cmake -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH="$(pwd)/../third-party" ../..
+$ cmake --build . -- -j $(sysctl -n hw.physicalcpu)
 
 ## Build Options
 | Name                           | Description                                                          | Default |

--- a/doc/build.md
+++ b/doc/build.md
@@ -65,8 +65,9 @@ $ cd mlio
 $ build-tools/build-dependency build/third-party all
 $ mkdir build/release
 $ cd build/release
-$ cmake -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH="$(pwd)/../third-party" ../..
-$ cmake --build . -- -j $(sysctl -n hw.physicalcpu)
+$ cmake -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH="$(pwd)/../third-party" ../..
+$ cmake --build . -- -j $(sysctl -n hw.ncpu)
+```
 
 ## Build Options
 | Name                           | Description                                                          | Default |


### PR DESCRIPTION
*Description of changes:*

* Mac defaults to the Apple version of clang. This modifies instructions for Mac users to use  LLVM/Clang that is installed via Homebrew.
* nproc is not available on mac, replaced with ```sysctl -n hw.physicalcpu```

*Test*
Built in local mac workspace


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
