### PR TITLE
Add duplicate column name handling in CsvReader

### DIFF
--- a/include/mlio/csv_reader.h
+++ b/include/mlio/csv_reader.h
@@ -59,6 +59,10 @@ struct MLIO_API csv_params final {
     /// A boolean value indicating whether the dataset has a header row
     /// only in the first data store.
     bool has_single_header = false;
+    /// A boolean value indiciating whether duplicate columns should be
+    /// renamed. If true, duplicate columns 'X', ..., 'X' will be
+    /// renamed to 'X', 'X_1', X_2', ...
+    bool dedupe_column_names = true;
     /// The column names.
     ///
     /// @note

--- a/src/mlio-py/mlio/core/data_reader.cxx
+++ b/src/mlio-py/mlio/core/data_reader.cxx
@@ -153,6 +153,7 @@ make_csv_reader_params(
     std::unordered_map<std::size_t, data_type> column_types_by_index,
     std::optional<std::size_t> header_row_index,
     bool has_single_header,
+    bool dedupe_column_names,
     char delimiter,
     char quote_char,
     std::optional<char> comment_char,
@@ -175,6 +176,7 @@ make_csv_reader_params(
     csv_prm.column_types_by_index = std::move(column_types_by_index);
     csv_prm.header_row_index = header_row_index;
     csv_prm.has_single_header = has_single_header;
+    csv_prm.dedupe_column_names = dedupe_column_names;
     csv_prm.delimiter = delimiter;
     csv_prm.quote_char = quote_char;
     csv_prm.comment_char = comment_char;
@@ -391,6 +393,7 @@ register_data_readers(py::module &m)
                  std::unordered_map<std::size_t, data_type>{},
              "header_row_index"_a = 0,
              "has_single_header"_a = false,
+             "dedupe_column_names"_a = true,
              "delimiter"_a = ',',
              "quote_char"_a = '"',
              "comment_char"_a = std::nullopt,
@@ -465,6 +468,10 @@ register_data_readers(py::module &m)
             has_single_header : bool, optional
                 A boolean value indicating whether the dataset has a header row
                 only in the first data store.
+            dedupe_column_names: bool, optional
+                A boolean value indiciating whether duplicate columns should be
+                renamed. If true, duplicate columns 'X', ..., 'X' will be
+                renamed to 'X', 'X_1', X_2', ...
             delimiter : char
                 The delimiter character.
             quote_char : char
@@ -504,6 +511,7 @@ register_data_readers(py::module &m)
                        &csv_params::column_types_by_index)
         .def_readwrite("header_row_index", &csv_params::header_row_index)
         .def_readwrite("has_single_header", &csv_params::has_single_header)
+        .def_readwrite("dedupe_column_names", &csv_params::dedupe_column_names)
         .def_readwrite("delimiter", &csv_params::delimiter)
         .def_readwrite("quote_char", &csv_params::quote_char)
         .def_readwrite("comment_char", &csv_params::comment_char)

--- a/tests/mlio-py-test/test_csv_reader.py
+++ b/tests/mlio-py-test/test_csv_reader.py
@@ -1,0 +1,124 @@
+from typing import List
+
+import numpy as np
+import pytest
+
+import mlio
+from mlio.integ.numpy import as_numpy
+
+
+def _test_dedupe_column_names(
+        tmpdir,
+        input_column_names: List[str],
+        input_data: List[int],
+        expected_column_names: List[str],
+        expected_data: List[int],
+        dedupe_column_names: bool = True,
+        **kwargs
+        ) -> None:
+
+    header_str = ','.join(input_column_names)
+    data_str = ','.join(str(x) for x in input_data)
+    csv_file = tmpdir.join("test.csv")
+    csv_file.write(header_str + '\n' + data_str)
+
+    dataset = [mlio.File(str(csv_file))]
+    reader_params = mlio.DataReaderParams(dataset=dataset, batch_size=1)
+    csv_params = mlio.CsvReaderParams(
+        dedupe_column_names=dedupe_column_names,
+        **kwargs
+    )
+    reader = mlio.CsvReader(reader_params, csv_params)
+
+    example = reader.read_example()
+    names = [desc.name for desc in example.schema.descriptors]
+    assert names == expected_column_names
+
+    record = [as_numpy(feature) for feature in example]
+    assert np.all(np.array(record).squeeze() == np.array(expected_data))
+
+
+def test_dedupe_column_names_no_duplicates(tmpdir):
+    _test_dedupe_column_names(
+        tmpdir,
+        input_column_names=["foo", "bar", "baz"],
+        input_data=[1, 2, 3],
+        expected_column_names=["foo", "bar", "baz"],
+        expected_data=[1, 2, 3]
+    )
+
+
+def test_dedupe_column_names_duplicates(tmpdir):
+    _test_dedupe_column_names(
+        tmpdir,
+        input_column_names=["foo", "bar", "bar", "bar", "foo"],
+        input_data=[1, 2, 3, 4, 5],
+        expected_column_names=["foo", "bar", "bar_1", "bar_2", "foo_1"],
+        expected_data=[1, 2, 3, 4, 5]
+    )
+
+
+def test_dedupe_column_names_duplicates_recursive(tmpdir):
+    _test_dedupe_column_names(
+        tmpdir,
+        input_column_names=["foo", "foo", "foo_1", "foo_1", "bar"],
+        input_data=[1, 2, 3, 4, 5],
+        expected_column_names=["foo", "foo_1", "foo_1_1", "foo_1_2", "bar"],
+        expected_data=[1, 2, 3, 4, 5]
+    )
+
+
+def test_dedupe_column_names_false(tmpdir):
+    with pytest.raises(mlio.SchemaError):
+        _test_dedupe_column_names(
+            tmpdir,
+            input_column_names=["foo", "foo", "bar"],
+            input_data=[1, 2, 3],
+            expected_column_names=["", "", ""],  # placeholder; error expected
+            expected_data=[0, 0, 0],  # placeholder
+            dedupe_column_names=False
+        )
+
+
+def test_dedupe_column_names_use_columns(tmpdir):
+    _test_dedupe_column_names(
+        tmpdir,
+        input_column_names=["foo", "foo", "bar", "baz"],
+        input_data=[1, 2, 3, 4],
+        expected_column_names=["bar", "baz"],
+        expected_data=[3, 4],
+        use_columns={"bar", "baz"}
+    )
+
+
+def test_dedupe_column_names_duplicates_use_columns(tmpdir):
+    _test_dedupe_column_names(
+        tmpdir,
+        input_column_names=["foo", "foo", "bar", "baz"],
+        input_data=[1, 2, 3, 4],
+        expected_column_names=["foo", "foo_1", "baz"],
+        expected_data=[1, 2, 4],
+        use_columns={"foo", "baz"}
+    )
+
+
+def test_dedupe_column_names_use_columns_by_index(tmpdir):
+    _test_dedupe_column_names(
+        tmpdir,
+        input_column_names=["foo", "foo", "bar", "baz"],
+        input_data=[1, 2, 3, 4],
+        expected_column_names=["bar", "baz"],
+        expected_data=[3, 4],
+        use_columns_by_index={2, 3}
+    )
+
+
+def test_dedupe_column_names_duplicates_use_columns_by_index(tmpdir):
+    _test_dedupe_column_names(
+        tmpdir,
+        input_column_names=["foo", "foo", "bar", "baz"],
+        input_data=[1, 2, 3, 4],
+        expected_column_names=["foo", "foo_1", "baz"],
+        expected_data=[1, 2, 4],
+        use_columns_by_index={0, 1, 3}
+    )


### PR DESCRIPTION
*Description of changes:*

This PR introduces an optional parameter named `dedupe_column_names` in `CsvReader` to handle duplicate column names. The [current behavior](https://github.com/awslabs/ml-io/commit/8f1bcc6bc0ad2f710ab5974f40765d27b8a27352) of CsvReader is to throw an error when there are duplicate column names. When `dedupe_column_names` is true (optional, true by default), duplicate column names `X`, ... , `X` are renamed to `X`, `X_1`, `X_2`, similarly to Pandas's `pd.read_csv(mangle_dupe_cols=True)`.

*Testing:*
`clang-format-9`
Build succeeded with `-DMLIO_TREAT_WARNINGS_AS_ERRORS=ON -MLIO_ENABLE_ASAN=ON -MLIO_ENABLE_USAN=ON -MLIO_USE_CLANG_TIDY=ON`.
New pytest unit tests added.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
