### PR TITLE
add numeric_int_count and unique value counts to mlio insights contrib

### DIFF
--- a/src/mlio-py/mlio/contrib/insights/README.md
+++ b/src/mlio-py/mlio/contrib/insights/README.md
@@ -49,21 +49,23 @@ Each column in this Example will print a dictionary like the following:
 
 ```
 {
-    'rows_seen': '2305812', 
-    'numeric_count': '2305761', 
-    'numeric_nan_count': '51', 
-    'string_empty_count': '0', 
-    'string_min_length': '2', 
-    'string_min_length_not_empty': '2', 
-    'string_max_length': '2', 
-    'string_only_whitespace_count': '0', 
-    'string_null_like_count': '0', 
-    'numeric_mean': '40.936210', 
-    'numeric_min': '18.000000', 
-    'numeric_max': '95.000000', 
-    'example_value': '', 
-    'string_cardinality': 78, 
-    'string_captured_unique_values': {'70', '38', '80', '30', '84', '82', '42', '53', '73', '75', '95', 'V1', '35', '74', '64', '36', '39', '60', '61', '44', '33', '85', '90', '66', '41', '56', '67', '79', '22', '54', '46', '37', '51', '81', '62', '65', '93', '28', '24', '88', '68', '57', '59', '21', '71', '72', '76', '78', '34', '29', '19', '48', '23', '94', '83', '92', '87', '58', '18', '32', '45', '63', '69', '86', '27', '89', '20', '55', '77', '31', '47', '26', '49', '43', '52', '50', '40', '25'}, 
+    'rows_seen': '109435',
+    'numeric_count': '109435',
+    'numeric_finite_count': '109435',
+    'numeric_nan_count': '0',
+    'numeric_int_count': '5760',
+    'string_empty_count': '0',
+    'string_min_length': '1',
+    'string_min_length_not_empty': '1',
+    'string_max_length': '3',
+    'string_only_whitespace_count': '0',
+    'string_null_like_count': '0',
+    'numeric_finite_mean': '5.863193',
+    'numeric_finite_min': '4.600000',
+    'numeric_finite_max': '7.700000',
+    'example_value': '5.1',
+    'string_cardinality': 16,
+    'string_captured_unique_values': {'6.5': 5760, '6.4': 5760, '5.7': 5760, '6.1': 5760, '5': 5760, '5.6': 11520, '6.7': 5760, '4.6': 5760, '5.9': 5760, '7.7': 11520, '6.2': 5760, '5.8': 11520, '5.4': 5760, '4.7': 5760, '4.9': 5760, '5.1': 5755},
     'string_captured_unique_values_overflowed': False
 }
 ```
@@ -82,6 +84,7 @@ The following information on each column is available:
 - `numeric_count`: the count of values that could be parsed as a float/double.
 - `numeric_nan_count`: the number of values that could not be parsed as a float/double.
 - `numeric_finite_count`: the number of non-infinity/non-NaN values.
+- `numeric_int_count`: the number of values that could be parsed as an integer.
 - `numeric_finite_mean`: the average of finite (non-infinite) numeric values seen.
 - `numeric_finite_min`: the minimum finite numeric value seen.
 - `numeric_finite_max`: the maximum finite numeric value seen.
@@ -98,5 +101,5 @@ The following information on each column is available:
 
 **Captured Values**
 - `example_value`: a value of the column sampled from the dataset.
-- `string_captured_unique_values`: if the column was specified in `capture_columns`; the first `max_capture_count` unique string values will be saved.
+- `string_captured_unique_values`: if the column was specified in `capture_columns`; the first `max_capture_count` unique string values and frequencies will be saved.
 - `string_captured_unique_values_overflowed`: if the column has more unique string values than `max_capture_count` this will be set to true.

--- a/src/mlio-py/mlio/contrib/insights/column_analyzer.cc
+++ b/src/mlio-py/mlio/contrib/insights/column_analyzer.cc
@@ -98,7 +98,7 @@ void Column_analyzer::analyze(const mlio::Example &example) const
                     numeric_column_sum += as_float;
                     numeric_column_count++;
 
-                    if (std::fmod(as_float, 1.0) == 0.0) {
+                    if ((std::abs(std::round(as_float) - as_float) <= 1.0e-5)) {
                         stats.numeric_int_count++;
                     }
 

--- a/src/mlio-py/mlio/contrib/insights/column_analyzer.cc
+++ b/src/mlio-py/mlio/contrib/insights/column_analyzer.cc
@@ -98,6 +98,10 @@ void Column_analyzer::analyze(const mlio::Example &example) const
                     numeric_column_sum += as_float;
                     numeric_column_count++;
 
+                    if (std::fmod(as_float, 1.0) == 0.0) {
+                        stats.numeric_int_count++;
+                    }
+
                     if (std::isnan(stats.numeric_finite_min) ||
                         as_float < stats.numeric_finite_min) {
                         stats.numeric_finite_min = as_float;
@@ -114,7 +118,7 @@ void Column_analyzer::analyze(const mlio::Example &example) const
             // Capture the values if specified.
             if (should_capture && !stats.str_captured_unique_values_overflowed) {
                 if (stats.str_captured_unique_values.size() < max_capture_count_) {
-                    stats.str_captured_unique_values.emplace(cell);
+                    ++stats.str_captured_unique_values[cell];
                 }
                 else if (stats.str_captured_unique_values.find(cell) ==
                          stats.str_captured_unique_values.end()) {

--- a/src/mlio-py/mlio/contrib/insights/column_analyzer.cc
+++ b/src/mlio-py/mlio/contrib/insights/column_analyzer.cc
@@ -87,7 +87,7 @@ void Column_analyzer::analyze(const mlio::Example &example) const
 
             // Numeric analyzers
             double as_float{};
-            if (mlio::try_parse_float(cell, as_float) != mlio::Parse_result::ok) {
+            if (mlio::try_parse_float(cell, as_float) != mlio::Parse_result::ok || std::isnan(as_float)) {
                 stats.numeric_nan_count++;
             }
             else {

--- a/src/mlio-py/mlio/contrib/insights/column_statistics.h
+++ b/src/mlio-py/mlio/contrib/insights/column_statistics.h
@@ -52,6 +52,7 @@ public:
     std::size_t numeric_count{};
     std::size_t numeric_nan_count{};
     std::size_t numeric_finite_count{};
+    std::size_t numeric_int_count{};
     double numeric_finite_mean{};
     double numeric_finite_min = std::numeric_limits<double>::quiet_NaN();
     double numeric_finite_max = std::numeric_limits<double>::quiet_NaN();
@@ -62,7 +63,7 @@ public:
     std::size_t str_empty_count{};
     std::size_t str_only_whitespace_count{};
     std::size_t str_null_like_count{};
-    std::unordered_set<std::string> str_captured_unique_values{};
+    std::unordered_map<std::string, int> str_captured_unique_values{};
     bool str_captured_unique_values_overflowed{};
 
     std::string example_value{};

--- a/src/mlio-py/mlio/contrib/insights/module.cc
+++ b/src/mlio-py/mlio/contrib/insights/module.cc
@@ -100,6 +100,7 @@ PYBIND11_MODULE(insights, m)
         {"numeric_count", &Column_analysis::numeric_count},
         {"numeric_finite_count", &Column_analysis::numeric_count},
         {"numeric_nan_count", &Column_analysis::numeric_nan_count},
+        {"numeric_int_count", &Column_analysis::numeric_int_count},
         {"string_empty_count", &Column_analysis::str_empty_count},
         {"string_min_length", &Column_analysis::str_min_length},
         {"string_min_length_not_empty", &Column_analysis::str_min_length_not_empty},


### PR DESCRIPTION
*Description of changes:*
* Add `numeric_int_count` to metadata collected by mlio insights
* Changed `string_captured_unique_values` to also include counts of each unique element
* Fixed `numeric_nan_count` to include `nan` values
* Updated README


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
