### PR TITLE
Add vocab cardinality and avg str length to mlio insights

### DIFF
--- a/src/mlio-py/mlio/contrib/insights/README.md
+++ b/src/mlio-py/mlio/contrib/insights/README.md
@@ -58,6 +58,7 @@ Each column in this Example will print a dictionary like the following:
     'string_min_length': '1',
     'string_min_length_not_empty': '1',
     'string_max_length': '3',
+    'string_avg_length': '2.250000',
     'string_only_whitespace_count': '0',
     'string_null_like_count': '0',
     'numeric_finite_mean': '5.863193',
@@ -66,6 +67,7 @@ Each column in this Example will print a dictionary like the following:
     'numeric_finite_median_approx': '6.0',
     'example_value': '5.1',
     'string_cardinality': 16,
+    `string_vocab_cardinality`: 16,
     'string_captured_unique_values': {'6.5': 5760, '6.4': 5760, '5.7': 5760, '6.1': 5760, '5': 5760, '5.6': 11520, '6.7': 5760, '4.6': 5760, '5.9': 5760, '7.7': 11520, '6.2': 5760, '5.8': 11520, '5.4': 5760, '4.7': 5760, '4.9': 5760, '5.1': 5755},
     'string_captured_unique_values_overflowed': False
 }
@@ -94,12 +96,15 @@ The following information on each column is available:
 **String Analysis**
 
 - `string_cardinality`: an approximation for the cardinality for values as strings (e.g. `1.0` and `1` are considered different).
+- `string_vocab_cardinality`: an approximation for the number of unique words seen across all values (delimited by space).
 - `string_min_length`: the minimum length of a string encountered in this column.
 - `string_min_length_not_empty`: the minimum length of a string encountered in this column that was not empty.
 - `string_max_length`: the minimum length of a string encountered in this column.
+- `string_avg_length`: the average length of a string across the entire column.
 - `string_empty_count`: the number of values without any characters.
 - `string_only_whitespace_count`: the number of values with only whitespace characters.
 - `string_null_like_count`: the number of values that match the `null_like_values` option in a case-insensitive manner.
+
 
 **Captured Values**
 - `example_value`: a value of the column sampled from the dataset.

--- a/src/mlio-py/mlio/contrib/insights/README.md
+++ b/src/mlio-py/mlio/contrib/insights/README.md
@@ -61,6 +61,7 @@ Each column in this Example will print a dictionary like the following:
     'string_avg_length': '2.250000',
     'string_only_whitespace_count': '0',
     'string_null_like_count': '0',
+    'string_num_words': 16,
     'numeric_finite_mean': '5.863193',
     'numeric_finite_min': '4.600000',
     'numeric_finite_max': '7.700000',

--- a/src/mlio-py/mlio/contrib/insights/README.md
+++ b/src/mlio-py/mlio/contrib/insights/README.md
@@ -96,7 +96,7 @@ The following information on each column is available:
 **String Analysis**
 
 - `string_cardinality`: an approximation for the cardinality for values as strings (e.g. `1.0` and `1` are considered different).
-- `string_vocab_cardinality`: an approximation for the number of unique words seen across all values (delimited by space).
+- `string_vocab_cardinality`: an approximation for the number of unique words seen across all values (words are delimited by space).
 - `string_min_length`: the minimum length of a string encountered in this column.
 - `string_min_length_not_empty`: the minimum length of a string encountered in this column that was not empty.
 - `string_max_length`: the minimum length of a string encountered in this column.
@@ -104,6 +104,7 @@ The following information on each column is available:
 - `string_empty_count`: the number of values without any characters.
 - `string_only_whitespace_count`: the number of values with only whitespace characters.
 - `string_null_like_count`: the number of values that match the `null_like_values` option in a case-insensitive manner.
+- `string_num_words`: the number of total words seen in this column (words are delimited by space).
 
 
 **Captured Values**

--- a/src/mlio-py/mlio/contrib/insights/column_analyzer.cc
+++ b/src/mlio-py/mlio/contrib/insights/column_analyzer.cc
@@ -88,6 +88,7 @@ void Column_analyzer::analyze(const mlio::Example &example) const
             std::string token;
             while (std::getline(iss, token, ' ')) {
                 stats.str_vocab_cardinality_estimator_.add(token);
+                stats.str_num_words++;
             }
 
             if (mlio::is_whitespace_only(cell)) {

--- a/src/mlio-py/mlio/contrib/insights/column_analyzer.cc
+++ b/src/mlio-py/mlio/contrib/insights/column_analyzer.cc
@@ -16,6 +16,9 @@
 #include "column_analyzer.h"
 
 #include <cmath>
+#include <iostream>
+#include <sstream>
+#include <string>
 #include <string_view>
 
 #include "utils.h"
@@ -52,6 +55,8 @@ void Column_analyzer::analyze(const mlio::Example &example) const
         // time.
         double numeric_column_sum = 0.0;
         std::size_t numeric_column_count = 0.0;
+        long string_column_length_sum = 0;
+        std::size_t string_column_count = 0.0;
 
         for (const std::string &cell : cells) {
             // Capture the first Example.
@@ -74,7 +79,16 @@ void Column_analyzer::analyze(const mlio::Example &example) const
 
             stats.str_min_length_not_empty = std::min(stats.str_min_length_not_empty, cell.size());
 
+            string_column_length_sum += cell.size();
+            string_column_count++;
+
             stats.str_cardinality_estimator_.add(cell);
+
+            std::istringstream iss(cell);
+            std::string token;
+            while (std::getline(iss, token, ' ')) {
+                stats.str_vocab_cardinality_estimator_.add(token);
+            }
 
             if (mlio::is_whitespace_only(cell)) {
                 stats.str_only_whitespace_count++;
@@ -136,14 +150,17 @@ void Column_analyzer::analyze(const mlio::Example &example) const
             }
         }
 
-        // Update the mean of numeric values based on the entire range of
-        // values.
+        // Update the mean of numeric values based on the entire range of values.
         auto ncc = static_cast<double>(numeric_column_count);
         auto nfc = static_cast<double>(stats.numeric_finite_count);
-
         double numeric_column_mean = numeric_column_sum / ncc;
-
         stats.numeric_finite_mean += (numeric_column_mean - stats.numeric_finite_mean) * ncc / nfc;
+
+        // Update average length of string values baseed on entire range of values.
+        auto scc = static_cast<double>(string_column_count);
+        auto rows_seen = static_cast<double>(stats.rows_seen);
+        double string_column_avg_length = string_column_length_sum / scc;
+        stats.str_avg_length += (string_column_avg_length - stats.str_avg_length) * scc / rows_seen;
     }
 };
 

--- a/src/mlio-py/mlio/contrib/insights/column_statistics.h
+++ b/src/mlio-py/mlio/contrib/insights/column_statistics.h
@@ -82,6 +82,7 @@ public:
     std::size_t str_empty_count{};
     std::size_t str_only_whitespace_count{};
     std::size_t str_null_like_count{};
+    std::size_t str_num_words{};
     double str_avg_length{};
     std::unordered_map<std::string, int> str_captured_unique_values{};
     bool str_captured_unique_values_overflowed{};

--- a/src/mlio-py/mlio/contrib/insights/column_statistics.h
+++ b/src/mlio-py/mlio/contrib/insights/column_statistics.h
@@ -36,7 +36,8 @@ private:
 
 public:
     explicit Column_analysis(std::string name)
-        : column_name{std::move(name)}, str_cardinality_estimator_{cardinality_hill_size}
+        : column_name{std::move(name)}, str_cardinality_estimator_{cardinality_hill_size},
+        str_vocab_cardinality_estimator_{cardinality_hill_size}
     {}
 
 public:
@@ -58,6 +59,12 @@ public:
     }
 
 public:
+    std::size_t estimate_string_vocab_cardinality() const
+    {
+        return static_cast<std::size_t>(std::round(str_vocab_cardinality_estimator_.estimate()));
+    }
+
+public:
     std::string column_name;
 
     std::size_t rows_seen{};
@@ -75,6 +82,7 @@ public:
     std::size_t str_empty_count{};
     std::size_t str_only_whitespace_count{};
     std::size_t str_null_like_count{};
+    double str_avg_length{};
     std::unordered_map<std::string, int> str_captured_unique_values{};
     bool str_captured_unique_values_overflowed{};
 
@@ -82,6 +90,7 @@ public:
 
 private:
     hll::HyperLogLog str_cardinality_estimator_;
+    hll::HyperLogLog str_vocab_cardinality_estimator_;
     mutable std::vector<double> numeric_column_sample{};
 };
 

--- a/src/mlio-py/mlio/contrib/insights/module.cc
+++ b/src/mlio-py/mlio/contrib/insights/module.cc
@@ -93,6 +93,7 @@ PYBIND11_MODULE(insights, m)
         {"numeric_finite_mean", &Column_analysis::numeric_finite_mean},
         {"numeric_finite_min", &Column_analysis::numeric_finite_min},
         {"numeric_finite_max", &Column_analysis::numeric_finite_max},
+        {"string_avg_length", &Column_analysis::str_avg_length},
     };
 
     std::vector<std::pair<const char *, size_t Column_analysis::*>> long_stat_names = {
@@ -131,7 +132,10 @@ PYBIND11_MODULE(insights, m)
         ca_class.def_readwrite(name, method);
     }
 
-    ca_class.def("estimate_string_cardinality", &Column_analysis::estimate_string_cardinality);
+    ca_class.def("estimate_string_cardinality", 
+                 &Column_analysis::estimate_string_cardinality);
+    ca_class.def("estimate_string_vocab_cardinality", 
+                 &Column_analysis::estimate_string_vocab_cardinality);
 
     ca_class.def("to_dict", [=](const Column_analysis &self) {
         py::dict result{};
@@ -149,6 +153,7 @@ PYBIND11_MODULE(insights, m)
         }
 
         result["string_cardinality"] = self.estimate_string_cardinality();
+        result["string_vocab_cardinality"] = self.estimate_string_vocab_cardinality();
         result["string_captured_unique_values"] = self.str_captured_unique_values;
         result["string_captured_unique_values_overflowed"] =
             self.str_captured_unique_values_overflowed;

--- a/src/mlio-py/mlio/contrib/insights/module.cc
+++ b/src/mlio-py/mlio/contrib/insights/module.cc
@@ -108,6 +108,7 @@ PYBIND11_MODULE(insights, m)
         {"string_max_length", &Column_analysis::str_max_length},
         {"string_only_whitespace_count", &Column_analysis::str_only_whitespace_count},
         {"string_null_like_count", &Column_analysis::str_null_like_count},
+        {"string_num_words", &Column_analysis::str_num_words},
     };
 
     std::vector<std::pair<const char *, std::string Column_analysis::*>> str_stat_names = {


### PR DESCRIPTION
*Description of changes:*
* Add `string_avg_length` for the average length of strings
* Add `string_vocab_cardinality` for the number of unique words (vocab size)
* Add `string_num_words` for the number of total words seen


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
