### PR TITLE
Add cpu architecture agnostic code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,7 +282,7 @@ if(MLIO_INCLUDE_LIB)
     find_package(Iconv REQUIRED)
     find_package(natsort REQUIRED CONFIG)
     find_package(Protobuf 3.8 REQUIRED)
-    find_package(TBB 2019.0 REQUIRED CONFIG COMPONENTS tbb)
+    find_package(TBB REQUIRED CONFIG COMPONENTS tbb)
     find_package(Threads REQUIRED)
     find_package(ZLIB REQUIRED)
 

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -17,7 +17,7 @@ ExternalProject_Add(
     GIT_REPOSITORY
         https://github.com/abseil/abseil-cpp.git
     GIT_TAG
-        20190808
+        20210324.2
     CMAKE_ARGS
         -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
         -DCMAKE_BUILD_TYPE=Release
@@ -168,25 +168,20 @@ ExternalProject_Add(
         -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
 )
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    set(TIO_TBB_URL "https://github.com/intel/tbb/releases/download/2019_U8/tbb2019_20190605oss_lin.tgz")
-elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(TIO_TBB_URL "https://github.com/intel/tbb/releases/download/2019_U8/tbb2019_20190605oss_mac.tgz")
-else()
-    message(FATAL_ERROR "Intel TBB is only supported on Linux and macOS.")
-endif()
-
 ExternalProject_Add(
     #NAME
         tbb
     PREFIX
         ${CMAKE_CURRENT_BINARY_DIR}
-    URL
-        ${TIO_TBB_URL}
-    CONFIGURE_COMMAND
-        ""
-    BUILD_COMMAND
-        ""
-    INSTALL_COMMAND
-        cmake -E copy_directory <SOURCE_DIR>/tbb2019_20190605oss <INSTALL_DIR>
+    GIT_REPOSITORY
+        https://github.com/wjakob/tbb.git
+    GIT_TAG
+        ddbe45cd3ad89df9a84cd77013d5898fc48b8e89
+    CMAKE_ARGS
+        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
+        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+        -DBUILD_SHARED_LIBS=OFF
+        -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
 )


### PR DESCRIPTION
- Change third-party CMakeLists to build from source packages instead of binaries

*Issue #, if available:*

*Description of changes:*
Merging in separate branch to master to avoid redundant divergence. Have tested the builds of both arch types used in scikit-learn. The scikit-learn ARM Dockerfile required separate modifications unrelated to the changes in this package.